### PR TITLE
Create Uptycs and Pagerduty Integration Page Verbiage

### DIFF
--- a/docs/Uptycs and Pagerduty Integration Page Verbiage
+++ b/docs/Uptycs and Pagerduty Integration Page Verbiage
@@ -1,0 +1,29 @@
+Uptycs and Pagerduty Integration Page verbiage: 
+
+[Main Section]
+Security Analytics for the Modern Defender 
+
+Uptycs + PagerDuty helps teams solve incident response from detection to alert to action. The powerful detections and events framework from Uptycs gives teams deep visibility into their IT ecosystem. With PagerDuty, critical alerts from the Uptycs platform are getting into the right hands faster, helping expedite response and resolution times across endpoint, cloud, and container assets. 
+
+[For under the main description]
+* Detect and Investigate Attacks: Uptycs extends beyond endpoints to cover managed container services environments and the cloud infrastructure — tying together attack activity as it crosses on-premises and cloud boundaries.
+* Cloud Workload Protection Platform (CWPP): Complete security observability for your cloud workloads and collects and analyzes real-time workload activity in detail.
+* Cloud Security Posture Management (CSPM): Use connected insights from across your cloud accounts to prioritize misconfigurations and vulnerabilities for remediation. 
+* Cloud Infrastructure and Entitlements Management (CIEM): Highlight risky policies and overly permissive configurations, and receive alerts for potential account misuse.
+* eXtended Detection and Response (XDR): Correlated telemetry from productivity endpoints, server workloads, and other sources provide extended detection and response.
+
+[Resource Links with Preview of Documents]
+* Case study: Flexport empowers DevOps teams with security observability
+* Uptycs CIEM datasheet
+* Uptycs XDR datasheet
+
+[Documentation] 
+
+How it Works
+Configure Alerts and Events from Uptycs to be sent to the PagerDuty platform as an alert destination. Once in PagerDuty, use these alerts to notify any personnel using the PagerDuty platform.
+
+Integration Walkthrough
+Follow the link here to the github with instructions on setting up the integration: https://github.com/uptycslabs/pager-duty/blob/main/docs/PS-PagerDutyIntegration-270722-1648.pdf
+
+[Support]
+If you need help with this integration, please contact support@uptycs.com.


### PR DESCRIPTION
Git public file is Pagerduty's preferred method to send over the uptycs content for their web partner portal page.  Can this file be added to the uptycs pagerduty public repository?

Thanks
Bryan